### PR TITLE
handle interrupts while polling and sleeping

### DIFF
--- a/src/hid_linux.c
+++ b/src/hid_linux.c
@@ -244,7 +244,7 @@ fido_hid_open(const char *path)
 	struct hid_linux *ctx;
 	struct hidraw_report_descriptor *hrd;
 	struct timespec tv_pause;
-	long interval_ms, retries = 0;
+	long interval_ns, retries = 0;
 	bool looped;
 
 retry:
@@ -257,6 +257,9 @@ retry:
 	}
 
 	while (flock(ctx->fd, LOCK_EX|LOCK_NB) == -1) {
+		if (errno == EINTR) {
+			continue;
+		}
 		if (errno != EWOULDBLOCK) {
 			fido_log_error(errno, "%s: flock", __func__);
 			fido_hid_close(ctx);
@@ -268,11 +271,27 @@ retry:
 			fido_hid_close(ctx);
 			return (NULL);
 		}
-		interval_ms = retries * 100000000L;
-		tv_pause.tv_sec = interval_ms / 1000000000L;
-		tv_pause.tv_nsec = interval_ms % 1000000000L;
-		if (nanosleep(&tv_pause, NULL) == -1) {
-			fido_log_error(errno, "%s: nanosleep", __func__);
+		// Take the current time and add the required timeout so that we can use it with `TIMER_ABSTIME`
+		// below. We can't use nanosleep with a relative timer, because we might be interrupted multiple
+		// times and would then have to adjust for the time difference after the interrupt.
+		if (clock_gettime(CLOCK_MONOTONIC, &tv_pause) == -1) {
+			fido_log_error(errno, "%s: clock_gettime", __func__);
+			fido_hid_close(ctx);
+			return (NULL);
+		}
+		interval_ns = retries * 100000000L;
+		tv_pause.tv_sec += (interval_ns / 1000000000L);
+		tv_pause.tv_nsec += interval_ns % 1000000000L;
+		if (tv_pause.tv_nsec >= 1000000000L) {
+			tv_pause.tv_sec += 1;
+			tv_pause.tv_nsec -= 1000000000L;
+		}
+		int r;
+		do {
+			r = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &tv_pause, NULL);
+		} while (r == EINTR);
+		if (r != 0) {
+			fido_log_error(r, "%s: clock_nanosleep", __func__);
 			fido_hid_close(ctx);
 			return (NULL);
 		}

--- a/src/hid_unix.c
+++ b/src/hid_unix.c
@@ -70,12 +70,9 @@ fido_hid_unix_wait(int fd, int ms, const fido_sigset_t *sigmask)
 		r = ppoll(&pfd, 1, ms > -1 ? &ts : NULL, sigmask);
 	} while (r == -1 && errno == EINTR);
 
-	if (r < 0) {
-		fido_log_error(errno, "%s: ppoll", __func__);
-		return (-1);
-	}
-	if (r == 0) {
-		fido_log_error(ETIME, "%s: ppoll timed out", __func__);
+	if (r < 1) {
+		if (r == -1)
+			fido_log_error(errno, "%s: ppoll", __func__);
 		return (-1);
 	}
 

--- a/src/hid_unix.c
+++ b/src/hid_unix.c
@@ -66,9 +66,16 @@ fido_hid_unix_wait(int fd, int ms, const fido_sigset_t *sigmask)
 		ts.tv_nsec = (ms % 1000) * 1000000;
 	}
 
-	if ((r = ppoll(&pfd, 1, ms > -1 ? &ts : NULL, sigmask)) < 1) {
-		if (r == -1)
-			fido_log_error(errno, "%s: ppoll", __func__);
+	do {
+		r = ppoll(&pfd, 1, ms > -1 ? &ts : NULL, sigmask);
+	} while (r == -1 && errno == EINTR);
+
+	if (r < 0) {
+		fido_log_error(errno, "%s: ppoll", __func__);
+		return (-1);
+	}
+	if (r == 0) {
+		fido_log_error(ETIME, "%s: ppoll timed out", __func__);
 		return (-1);
 	}
 

--- a/src/hid_unix.c
+++ b/src/hid_unix.c
@@ -50,7 +50,7 @@ fido_hid_unix_open(const char *path)
 int
 fido_hid_unix_wait(int fd, int ms, const fido_sigset_t *sigmask)
 {
-	struct timespec ts;
+	struct timespec ts, ts_end, ts_now;
 	struct pollfd pfd;
 	int r;
 
@@ -61,12 +61,39 @@ fido_hid_unix_wait(int fd, int ms, const fido_sigset_t *sigmask)
 #ifdef FIDO_FUZZ
 	return (0);
 #endif
+
 	if (ms > -1) {
-		ts.tv_sec = ms / 1000;
-		ts.tv_nsec = (ms % 1000) * 1000000;
+		// Calculate the absolute time at which the timeout expires
+		if (clock_gettime(CLOCK_MONOTONIC, &ts_end) == -1) {
+			fido_log_error(errno, "%s: clock_gettime", __func__);
+			return (-1);
+		}
+		ts_end.tv_sec += ms / 1000;
+		ts_end.tv_nsec += (ms % 1000) * 1000000;
+		if (ts_end.tv_nsec >= 1000000000L) {
+			ts_end.tv_sec += 1;
+			ts_end.tv_nsec -= 1000000000L;
+		}
 	}
 
 	do {
+		if (ms > -1) {
+			// Calculate the remaining timeout = ts_end - ts_now
+			if (clock_gettime(CLOCK_MONOTONIC, &ts_now) == -1) {
+				fido_log_error(errno, "%s: clock_gettime", __func__);
+				return (-1);
+			}
+			if (ts_now.tv_nsec > ts_end.tv_nsec) {
+				ts_now.tv_sec += 1;
+				ts.tv_nsec = 1000000000L - ts_now.tv_nsec + ts_end.tv_nsec;
+			} else {
+				ts.tv_nsec = ts_end.tv_nsec - ts_now.tv_nsec;
+			}
+			if (ts_now.tv_sec > ts_end.tv_sec) {
+				return (-1); // Timeout expired
+			}
+			ts.tv_sec = ts_end.tv_sec - ts_now.tv_sec;
+		}
 		r = ppoll(&pfd, 1, ms > -1 ? &ts : NULL, sigmask);
 	} while (r == -1 && errno == EINTR);
 


### PR DESCRIPTION
If a sleep or poll function returns EINTR than it
was interrupted by a signal (e.g. SIGPROF if the
application is beeing profiled). In that case one
should continue polling/sleeping.

Use clock_nanosleep instead of nanosleep to avoid
a time drift when the sleep is frequently interrupted, which again is the case when using a profiler.