### PR TITLE
fix get assert with U2F

### DIFF
--- a/src/assert.c
+++ b/src/assert.c
@@ -120,19 +120,19 @@ fido_dev_get_assert_tx(fido_dev_t *dev, fido_assert_t *assert,
 		}
 	}
 
-	if ((prot = fido_dev_get_pin_protocol(dev)) == 0) {
-		fido_log_debug("%s: fido_dev_get_pin_protocol", __func__);
-		r = FIDO_ERR_INTERNAL;
-		goto fail;
-	}
-
-	if (assert->ext.mask)
+	if (assert->ext.mask) {
+		if ((prot = fido_dev_get_pin_protocol(dev)) == 0) {
+			fido_log_debug("%s: fido_dev_get_pin_protocol", __func__);
+			r = FIDO_ERR_INTERNAL;
+			goto fail;
+		}
 		if ((argv[3] = cbor_encode_assert_ext(prot, &assert->ext, ecdh,
 		    pk)) == NULL) {
 			fido_log_debug("%s: cbor_encode_assert_ext", __func__);
 			r = FIDO_ERR_INTERNAL;
 			goto fail;
 		}
+	}
 
 	/* user verification */
 	if (pin != NULL || (uv == FIDO_OPT_TRUE &&
@@ -379,19 +379,19 @@ fido_dev_get_assert(fido_dev_t *dev, fido_assert_t *assert, const char *pin)
 		}
 	}
 
-	if ((prot = fido_dev_get_pin_protocol(dev)) == 0) {
-		fido_log_debug("%s: fido_dev_get_pin_protocol", __func__);
-		r = FIDO_ERR_INTERNAL;
-		goto fail;
-	}
-
 	r = fido_dev_get_assert_wait(dev, assert, pk, ecdh, pin, &ms);
-	if (r == FIDO_OK && (assert->ext.mask & FIDO_EXT_HMAC_SECRET))
+	if (r == FIDO_OK && (assert->ext.mask & FIDO_EXT_HMAC_SECRET)) {
+		if ((prot = fido_dev_get_pin_protocol(dev)) == 0) {
+			fido_log_debug("%s: fido_dev_get_pin_protocol", __func__);
+			r = FIDO_ERR_INTERNAL;
+			goto fail;
+		}
 		if (decrypt_hmac_secrets(prot, assert, ecdh) < 0) {
 			fido_log_debug("%s: decrypt_hmac_secrets", __func__);
 			r = FIDO_ERR_INTERNAL;
 			goto fail;
 		}
+	}
 
 fail:
 	es256_pk_free(&pk);


### PR DESCRIPTION
With commit fe5bb7d9612f85e71c83539d098aff35bca72f41 the PIN protocol version is queried in fido_dev_get_assert to decrypt or encrypt the hmac-secret. When the device is a U2F device, there is no PIN protocol, and get assert fails with FIDO_ERR_INTERNAL.
To fix that, the pin protocol version is only queried when a FIDO extension like hmac-secret is present, which implies no U2F.